### PR TITLE
Generate a CMake-time error if compiler+flags lacks deducing this support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,15 @@ cmake_minimum_required(VERSION 3.10)
 
 project(beman_iter_interface VERSION 0.0.0 LANGUAGES CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 include(FetchContent)
+include(CompilerFeatureTest)
+
+beman_iterator26_check_deducing_this(COMPILER_SUPPORTS_DEDUCING_THIS)
+
+if(NOT COMPILER_SUPPORTS_DEDUCING_THIS)
+  message(FATAL_ERROR "The selected compiler and flags lacks support C++23's deducing this, which is required to build this project. Try adding -DCMAKE_CXX_STANDARD=23 to your command line parameters and, failing that, upgrade your compiler.")
+endif()
 
 enable_testing()
 

--- a/cmake/CompilerFeatureTest.cmake
+++ b/cmake/CompilerFeatureTest.cmake
@@ -1,0 +1,15 @@
+# Functions that determine compiler capabilities
+
+include(CheckCXXSourceCompiles)
+
+# Determines if the selected C++ compiler has deducing this support. Sets
+# 'result_var' to whether support is detected.
+function(beman_iterator26_check_deducing_this result_var)
+  check_cxx_source_compiles( "
+#ifndef __cpp_explicit_this_parameter
+#error No deducing this support
+#endif
+int main(){}
+" HAVE_DEDUCING_THIS )
+  set(${result_var} ${HAVE_DEDUCING_THIS} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
This improves the user experience when incompatible flags are used. It
also is a first step toward resolving #10.
